### PR TITLE
Build ALVR client core framework from submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "ALVR"]
+	path = ALVR
+	url = https://github.com/alvr-org/ALVR.git
+	branch = master

--- a/build_and_repack.sh
+++ b/build_and_repack.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Get ALVR submodule
+git submodule update --init --recursive
+
+# Check if Rust is installed
+if command -v rustc &> /dev/null; then
+    echo "Rust is already installed."
+else
+    echo "Rust is not installed. Installing..."
+    curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh
+fi
+
+# Install or update cbindgen
+cargo install cbindgen
+
+# Add iOS target 
+rustup target add aarch64-apple-ios
+
+cargo build --manifest-path ALVR/Cargo.toml --target=aarch64-apple-ios -p alvr_client_core
+cd ALVR/alvr/client_core
+cbindgen --config cbindgen.toml --crate alvr_client_core --output ../../alvr_client_core.h
+cd ../../../
+
+sh repack_alvr_client.sh
+
+# Clean up ALVR build
+cargo clean --manifest-path ALVR/Cargo.toml
+rm ALVR/alvr_client_core.h

--- a/repack_alvr_client.sh
+++ b/repack_alvr_client.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
-BUILDDIR="/Volumes/orangehd/docs/repos/ALVR/target/aarch64-apple-ios/debug"
-HEADERPATH="/Volumes/orangehd/docs/repos/ALVR/alvr_client_core.h"
+BUILDDIR="ALVR/target/aarch64-apple-ios/debug"
+HEADERPATH="ALVR/alvr_client_core.h"
 rm -r alvrrepack ALVRClientCore.xcframework || true
 mkdir -p alvrrepack/ios alvrrepack/maccatalyst alvrrepack/xros alvrrepack/xrsimulator alvrrepack/headers
 cp "$BUILDDIR/libalvr_client_core.dylib" alvrrepack/ios


### PR DESCRIPTION
Added a build script to install macOS dependencies required for building ALVR and create the ALVRClientCore.xcframework locally.

This helped me get the xcode build running on my visionOS hardware and connecting to ALVR on Windows successfully.  Hopefully speeds up the process for anyone else wanting to test with their hardware.